### PR TITLE
ロードバランサーで WebSocket が切断される問題への対応

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,19 +13,20 @@ https://shiguredo.onlineornot.com
 お知らせ
 ========
 
-ロードバランサーで WebSocket が切断される問題への対応
+ロードバランサーで WebSocket が突然切断される問題への対応
 ------------------------------------------------------------------
 
 :日時: 2023-07-20
 
-ロードバランサー (以下 LB) を経由した場合に WebSocket が突然切断される問題があることがわかりました。
-これを回避するため、Sora Labo の Canary 版 Sora のシグナリング URL は LB を使わず、直接 Canary 版 Sora の URL を指定するように修正をしました。
+シグナリング URL の一本化に利用しているロードバランサー (以下 LB) を経由した場合、 WebSocket が突然切断される問題があることがわかりました。
+この問題をすぐに解決することは難しいため、 Sora Labo の Canary 版 Sora のシグナリング URL は LB を利用することを停止しました。そのため Canary 版 Sora のシグナリング URL が変更になります。
 
 ::
 
   (変更前) wss://canary.sora-labo.shiguredo.app/signaling
     ↓
-  (変更後) wss://0001.canary.sora-labo.shiguredo.app/signaling
+  (変更後) wss://<node-id>.canary.sora-labo.shiguredo.app/signaling
+  * <node-id> の箇所は "0001" などの文字列になります
 
 OBS (WebRTC) は WebSocket を利用しないため、以前通り LB を指定する方式にしています。
 

--- a/README.rst
+++ b/README.rst
@@ -364,7 +364,7 @@ Sora JavaScript SDK のサンプル集を利用して Sora Labo に接続でき�
 
 .. code-block::
 
-  VITE_DEFAULT_SIGNALING_URL=wss://canary.sora-labo.shiguredo.app/signaling
+  VITE_DEFAULT_SIGNALING_URL=wss://0001.canary.sora-labo.shiguredo.app/signaling
   VITE_DEFAULT_CHANNEL_ID=<自分の GitHub Username>_<自分の GitHub ID>_<好きなチャネル名>
   VITE_DEFAULT_ACCESS_TOKEN=<アクセストークン>
 
@@ -406,7 +406,7 @@ gradle.properties の作成::
 gradle.properties への設定例::
 
     # Setting Sora's signaling endpoint and channel_id
-    signaling_endpoint = wss://canary.sora-labo.shiguredo.app/signaling
+    signaling_endpoint = wss://0001.canary.sora-labo.shiguredo.app/signaling, wss://0002.canary.sora-labo.shiguredo.app/signaling, wss://0003.canary.sora-labo.shiguredo.app/signaling
     channel_id         = shiguredo_0_sora
 
     # Setting Signaling Metadata.
@@ -451,7 +451,9 @@ Environment.swift の作成::
 Environment.swift への設定例::
 
     // 接続するサーバーのシグナリング URL
-    static let urls = [URL(string: "wss://canary.sora-labo.shiguredo.app/signaling")!]
+    static let urls = [URL(string: "wss://0001.canary.sora-labo.shiguredo.app/signaling")!,
+                       URL(string: "wss://0002.canary.sora-labo.shiguredo.app/signaling")!,
+                       URL(string: "wss://0003.canary.sora-labo.shiguredo.app/signaling")!]
 
     // チャネル ID
     static let channelId = "shiguredo_0_sora"
@@ -479,7 +481,9 @@ GitHub Username が shiguredo で、 チャネル ID が sora-devtools の場合
 
     ./momo --resolution VGA --no-audio-device sora --auto \
         --signaling-url \
-            wss://canary.sora-labo.shiguredo.app/signaling \
+            wss://0001.canary.sora-labo.shiguredo.app/signaling \
+            wss://0002.canary.sora-labo.shiguredo.app/signaling \
+            wss://0003.canary.sora-labo.shiguredo.app/signaling \
         --channel-id shiguredo_0_sora \
         --role sendonly --multistream true --video-codec-type VP8 --video-bit-rate 2500 \
         --metadata '{"access_token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJjaGFubmVsX2lkIjoic29yYUBzaGlndXJlZG8jMCJ9.TYP-iQaMNcGF7xSxoa8QyqBveUyUQ6EobBc1djg1_is"}'

--- a/README.rst
+++ b/README.rst
@@ -25,7 +25,7 @@ https://shiguredo.onlineornot.com
 
   (変更前) wss://canary.sora-labo.shiguredo.app/signaling
     ↓
-  (変更後) wss://0001.canary.sora-labo.shiguredo.app/signaling ("0001" の箇所は "0001" から "0012" まで)
+  (変更後) wss://0001.canary.sora-labo.shiguredo.app/signaling
 
 OBS (WebRTC) は WebSocket を利用しないため、以前通り LB を指定する方式にしています。
 

--- a/README.rst
+++ b/README.rst
@@ -13,6 +13,23 @@ https://shiguredo.onlineornot.com
 お知らせ
 ========
 
+ロードバランサーで WebSocket が切断される問題への対応
+------------------------------------------------------------------
+
+:日時: 2023-07-20
+
+ロードバランサー (以下 LB) を経由した場合に WebSocket が突然切断される問題があることがわかりました。
+これを回避するため、Sora Labo の Canary 版 Sora のシグナリング URL は LB を使わず、直接 Canary 版 Sora の URL を指定するように修正をしました。
+
+::
+
+  (変更前) wss://canary.sora-labo.shiguredo.app/signaling
+    ↓
+  (変更後) wss://0001.canary.sora-labo.shiguredo.app/signaling ("0001" の箇所は "0001" から "0012" まで)
+
+OBS (WebRTC) は WebSocket を利用しないため、以前通り LB を指定する方式にしています。
+
+
 OBS (WebRTC) 対応
 ------------------------------------------------------
 


### PR DESCRIPTION
お知らせの追加と接続例の修正を行いました。

- sora-js-sdk-samples は複数シグナリングに対応していないと思うので 1 種類にしてあります。
- お知らせの内容についてこれでいいか確認いただけますか。