### PR TITLE
Sora Devtools の URL を canary 付きのドメインに切り替える

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,7 +276,7 @@ Sora Labo は検証目的以外での利用はできません。それ以外は 
 
 ### Sora DevTools を利用する
 
-[Sora DevTools](https://github.com/shiguredo/sora-devtools) という開発者ツールを <https://sora-devtools.shiguredo.jp/> にデプロイして公開しています。
+[Sora DevTools](https://github.com/shiguredo/sora-devtools) という開発者ツールを <https://canary.sora-devtools.shiguredo.app/> にデプロイして公開しています。
 
 ダッシュボードページに Sora DevTools をSora Labo 経由で利用できるように、
 チャネル ID とアクセストークンとシグナリング URL 埋め込んである URL を用意してあります。


### PR DESCRIPTION
Sora Labo ホーム画面の URL と連動させてドキュメント記載の URL も変更しました